### PR TITLE
Define `default_style_sheet_path` as `None`

### DIFF
--- a/superplot/plotlib/plot_mod.py
+++ b/superplot/plotlib/plot_mod.py
@@ -64,6 +64,7 @@ def appearance(plot_name):
     home_dir_locfile = os.path.join(os.path.dirname(script_dir), "user_home.txt")
 
     style_sheet_path = None
+    default_style_sheet_path = None
 
     if os.path.exists(home_dir_locfile):
         with open(home_dir_locfile, "rb") as f:


### PR DESCRIPTION
You can get an error here because you have unconditional usage of `default_style_sheet_path` following a conditional initialization of it.